### PR TITLE
[FIX] test-02 fails to run on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,8 @@ jobs:
             ls -la  /tmp/src/mialsuperresolutiontoolkit/data/code
             ls -la  /tmp/src/mialsuperresolutiontoolkit/data/derivatives
 
-            rm -R /tmp/src/mialsuperresolutiontoolkit/data/derivatives/*
+            # Remove existing derivatives produced by test-01
+            sudo rm -R /tmp/src/mialsuperresolutiontoolkit/data/derivatives/*
 
             #Execute BIDS App
             docker run -it --rm --entrypoint /app/run_srr_coverage.sh \


### PR DESCRIPTION
There was a `sudo` missing to remove derivatives generated by test-01 befor running test-02
Here is the fix:
https://github.com/Medical-Image-Analysis-Laboratory/mialsuperresolutiontoolkit/blob/cc901d42b0e31e92b56b8e29b86dcb6e041c3d35/.circleci/config.yml#L174-L175