### PR TITLE
FIX: Correct the links generated in "Link to code" by Nipype sphinx documenter extension.

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -55,7 +55,7 @@ extensions = ['sphinx.ext.autosectionlabel',
               'nbsphinx',
               'nipype.sphinxext.plot_workflow',
               'nipype.sphinxext.apidoc',
-              'nipype.sphinxext.documenter',
+              'pymialsrtk.sphinxext.documenter',
               'sphinxemoji.sphinxemoji',
               ]
 

--- a/pymialsrtk/sphinxext/documenter.py
+++ b/pymialsrtk/sphinxext/documenter.py
@@ -1,0 +1,89 @@
+"""Modified Nipype sphinx autodoc ext.
+
+Comes from Nipype https://github.com/nipy/nipype/blob/master/nipype/sphinxext/documenter.py.
+
+**Modifications:**
+
+* Use `get_url` from `pymialsrtk.sphinxext.gh` which correct the prefix of the URL to
+  http://github.com/Medical-Image-Analysis-Laboratory/mialsuperresolutiontoolkit.
+"""
+from sphinx.locale import _
+from sphinx.ext import autodoc
+from nipype.interfaces.base import BaseInterface
+from .gh import get_url
+
+_ClassDocumenter = autodoc.ClassDocumenter
+RST_CLASS_BLOCK = """
+.. index:: {name}
+.. _{module}.{name}:
+{name}
+{underline}
+`Link to code <{code_url}>`__
+"""
+
+
+class NipypeClassDocumenter(_ClassDocumenter):  # type: ignore
+    priority = 20
+
+    def add_directive_header(self, sig: str) -> None:
+        if self.doc_as_attr:
+            self.directivetype = "attribute"
+
+        # Copied from super
+        domain = getattr(self, "domain", "py")
+        directive = getattr(self, "directivetype", self.objtype)
+        name = self.format_name()
+        sourcename = self.get_sourcename()
+
+        is_interface = False
+        try:
+            is_interface = issubclass(self.object, BaseInterface)
+        except TypeError:
+            pass
+
+        if is_interface is True:
+            lines = RST_CLASS_BLOCK.format(
+                code_url=get_url(self.object),
+                module=self.modname,
+                name=name,
+                underline="=" * len(name),
+            )
+            for line in lines.splitlines():
+                self.add_line(line, sourcename)
+        else:
+            self.add_line(
+                ".. %s:%s:: %s%s" % (domain, directive, name, sig), sourcename
+            )
+            if self.options.noindex:
+                self.add_line("   :noindex:", sourcename)
+            if self.objpath:
+                # Be explicit about the module, this is necessary since .. class::
+                # etc. don't support a prepended module name
+                self.add_line("   :module: %s" % self.modname, sourcename)
+
+        # add inheritance info, if wanted
+        if not self.doc_as_attr and self.options.show_inheritance:
+            sourcename = self.get_sourcename()
+            self.add_line("", sourcename)
+            bases = getattr(self.object, "__bases__", [])
+            bases_links = []
+
+            for b in bases:
+                based_interface = False
+                try:
+                    based_interface = issubclass(b, BaseInterface)
+                except TypeError:
+                    pass
+
+                if b.__module__ in ("__builtin__", "builtins"):
+                    bases_links.append(":class:`%s`" % b.__name__)
+                elif based_interface:
+                    bases_links.append(":ref:`%s.%s`" % (b.__module__, b.__name__))
+                else:
+                    bases_links.append(":class:`%s.%s`" % (b.__module__, b.__name__))
+
+            self.add_line("   " + _("Bases: %s") % ", ".join(bases_links), sourcename)
+
+
+def setup(app):
+    app.add_autodocumenter(NipypeClassDocumenter)

--- a/pymialsrtk/sphinxext/gh.py
+++ b/pymialsrtk/sphinxext/gh.py
@@ -1,0 +1,32 @@
+"""Build a file URL."""
+import os
+import inspect
+import subprocess
+
+REVISION_CMD = "git rev-parse --short HEAD"
+
+
+def _get_git_revision():
+    # Comes from scikit-learn
+    # https://github.com/scikit-learn/scikit-learn/blob/master/doc/sphinxext/github_link.py
+    try:
+        revision = subprocess.check_output(REVISION_CMD.split()).strip()
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return revision.decode("utf-8")
+
+
+def get_url(obj):
+    """Return local or remote url for an object."""
+    # Comes from Nipype
+    # https://github.com/nipy/nipype/blob/master/nipype/sphinxext/gh.py
+    # URL was updated to http://github.com/Medical-Image-Analysis-Laboratory/mialsuperresolutiontoolkit
+    filename = inspect.getsourcefile(obj)
+    uri = "file://%s" % filename
+    revision = _get_git_revision()
+    if revision is not None:
+        shortfile = os.path.join("pymialsrtk", filename.split("pymialsrtk/")[-1])
+        uri = "http://github.com/Medical-Image-Analysis-Laboratory/mialsuperresolutiontoolkit/blob/%s/%s" % (revision, shortfile)
+    lines, lstart = inspect.getsourcelines(obj)
+    lend = len(lines) + lstart
+    return "%s#L%d-L%d" % (uri, lstart, lend)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ packages = [
     "pymialsrtk.cli",
     "pymialsrtk.interfaces",
     "pymialsrtk.pipelines",
-    "pymialsrtk.pipelines.anatomical"
+    "pymialsrtk.pipelines.anatomical",
+    "pymialsrtk.sphinxext",
 ]
 
 package_data = {

--- a/setup_pypi.py
+++ b/setup_pypi.py
@@ -25,7 +25,8 @@ packages = [
     "pymialsrtk.cli",
     "pymialsrtk.interfaces",
     "pymialsrtk.pipelines",
-    "pymialsrtk.pipelines.anatomical"
+    "pymialsrtk.pipelines.anatomical",
+    "pymialsrtk.sphinxext",
 ]
 
 package_data = {


### PR DESCRIPTION
* Add `pymialsrtk.sphinxext` module that integrates a copy of `nipype/sphinxext/documenter.py` and `nipype/sphinxext/gh.py`  where the URL in `get_url` causing the issue in the generation of the "Link to code" in the docs has been updated to https://github.com/Medical-Image-Analysis-Laboratory/mialsuperresolutiontoolkit/.