### PR TITLE
Compute SDI on non-NLM denoised images 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       SCRATCH: "/scratch"
     docker:
       - image: docker:19.03.1-git 
-    working_directory: tmp/src/mialsuperresolutiontoolkit
+    working_directory: /tmp/src/mialsuperresolutiontoolkit
     steps:
       - run:
           name: "Install parallel gzip and python2"

--- a/pymialsrtk/interfaces/reconstruction.py
+++ b/pymialsrtk/interfaces/reconstruction.py
@@ -458,13 +458,6 @@ class MialsrtkSDIComputationInputSpec(BaseInterfaceInputSpec):
     """Class used to represent inputs of the
     MialsrtkSDIComputation interface."""
 
-    # in_roi = traits.Enum('mask', "all", "box", "mask",
-    #                      desc="""Define region of interest (required):
-    #                                - `box`: Use intersections for roi calculation
-    #                                - `mask`: Use masks for roi calculation
-    #                                - `all`: Use the whole image FOV""",
-    #                      mandatory=True,
-    #                      usedefault=True)
     input_images = InputMultiPath(File(), desc='Input images', mandatory=True)
     input_masks = InputMultiPath(File(),
                                  desc='Masks of the input images',
@@ -490,7 +483,8 @@ class MialsrtkSDIComputationOutputSpec(TraitedSpec):
 
 class MialsrtkSDIComputation(BaseInterface):
     """Creates a high-resolution image
-    from a set of low resolution images Todo.
+    from a set of low resolution images and
+    their slice-by-slicemotion parameters.
 
     """
 

--- a/pymialsrtk/interfaces/reconstruction.py
+++ b/pymialsrtk/interfaces/reconstruction.py
@@ -450,14 +450,13 @@ class MialsrtkTVSuperResolution(BaseInterface):
         return outputs
 
 
-
-
 ########################
 # Image Reconstruction
 ########################
 
 class MialsrtkSDIComputationInputSpec(BaseInterfaceInputSpec):
-    """Class used to represent inputs of the MialsrtkSDIComputation interface."""
+    """Class used to represent inputs of the
+    MialsrtkSDIComputation interface."""
 
     # in_roi = traits.Enum('mask', "all", "box", "mask",
     #                      desc="""Define region of interest (required):
@@ -466,29 +465,32 @@ class MialsrtkSDIComputationInputSpec(BaseInterfaceInputSpec):
     #                                - `all`: Use the whole image FOV""",
     #                      mandatory=True,
     #                      usedefault=True)
-    input_images = InputMultiPath(File(), desc='Input images', mandatory = True)
+    input_images = InputMultiPath(File(), desc='Input images', mandatory=True)
     input_masks = InputMultiPath(File(),
-                                 desc='Masks of the input images', mandatory = True)
+                                 desc='Masks of the input images',
+                                 mandatory = True)
     input_transforms = InputMultiPath(File(),
-                                  desc='Input transformation files', mandatory = True)
+                                      desc='Input transformation files',
+                                      mandatory=True)
     input_reference = File( desc='Input reference image', mandatory = True)
     sub_ses = traits.Str("x",
                          desc='Subject and session BIDS identifier to construct output filename',
                          usedefault=True)
     stacks_order = traits.List(mandatory=True,
-                               desc='List of stack run-id that specify the order of the stacks')
+                               desc='List of stack run-id that '
+                                    'specify the order of the stacks')
 
 
 class MialsrtkSDIComputationOutputSpec(TraitedSpec):
-    """Class used to represent outputs of the MialsrtkSDIComputation interface."""
+    """Class used to represent outputs of the
+    MialsrtkSDIComputation interface."""
 
     output_sdi = File(desc='Output scattered data interpolation image file')
 
 
 class MialsrtkSDIComputation(BaseInterface):
-    """Creates a high-resolution image from a set of low resolution images Todo.
-
-    >>> f
+    """Creates a high-resolution image
+    from a set of low resolution images Todo.
 
     """
 
@@ -528,14 +530,18 @@ class MialsrtkSDIComputation(BaseInterface):
         params = []
         # params.append(''.join(["--", self.inputs.in_roi]))
 
-        input_images = reorder_by_run_ids(self.inputs.input_images, self.inputs.stacks_order)
-        input_masks = reorder_by_run_ids(self.inputs.input_masks, self.inputs.stacks_order)
-        input_transforms = reorder_by_run_ids(self.inputs.input_transforms, self.inputs.stacks_order)
+        input_images = reorder_by_run_ids(self.inputs.input_images,
+                                          self.inputs.stacks_order)
+        input_masks = reorder_by_run_ids(self.inputs.input_masks,
+                                         self.inputs.stacks_order)
+        input_transforms = reorder_by_run_ids(self.inputs.input_transforms,
+                                              self.inputs.stacks_order)
 
         params.append("-r")
         params.append(empty_ref_image)
 
-        for in_image, in_mask, in_transform in zip(input_images, input_masks, input_transforms):
+        for in_image, in_mask, in_transform in \
+                zip(input_images, input_masks, input_transforms):
 
             params.append("-i")
             params.append(in_image)
@@ -559,7 +565,7 @@ class MialsrtkSDIComputation(BaseInterface):
         try:
             print('... cmd: {}'.format(cmd))
             cmd = ' '.join(cmd)
-            run(cmd) #, cwd=os.getcwd())
+            run(cmd)
         except Exception as e:
             print('Failed')
             print(e)

--- a/pymialsrtk/pipelines/anatomical/srr.py
+++ b/pymialsrtk/pipelines/anatomical/srr.py
@@ -402,13 +402,15 @@ class AnatomicalPipeline:
         srtkImageReconstruction.inputs.no_reg = self.m_skip_svr
 
         if self.m_do_nlm_denoising:
-            srtkMaskImage01_nlm = MapNode(interface=preprocess.MialsrtkMaskImage(),
-                                      name='srtkMaskImage01_nlm',
-                                      iterfield=['in_file', 'in_mask'])
+            srtkMaskImage01_nlm = MapNode(
+                interface=preprocess.MialsrtkMaskImage(),
+                name='srtkMaskImage01_nlm',
+                iterfield=['in_file', 'in_mask'])
             srtkMaskImage01_nlm.inputs.bids_dir = self.bids_dir
 
-            sdiComputation = Node(interface=reconstruction.MialsrtkSDIComputation(),
-                                      name='sdiComputation')
+            sdiComputation = Node(
+                interface=reconstruction.MialsrtkSDIComputation(),
+                name='sdiComputation')
             sdiComputation.inputs.sub_ses = sub_ses
             sdiComputation.inputs.stacks_order = self.m_stacks
 
@@ -479,40 +481,53 @@ class AnatomicalPipeline:
                         srtkMaskImage01, "in_file")
 
         if self.m_do_nlm_denoising:
-            self.wf.connect(preprocessing_stage, ("outputnode.output_images_nlm", utils.sort_ascending),
+            self.wf.connect(preprocessing_stage, ("outputnode.output_images_nlm",
+                                                  utils.sort_ascending),
                             srtkMaskImage01_nlm, "in_file")
             self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending),
                             srtkMaskImage01_nlm, "in_mask")
 
-            self.wf.connect(srtkMaskImage01_nlm, "out_im_file", srtkImageReconstruction, "input_images")
+            self.wf.connect(srtkMaskImage01_nlm, "out_im_file",
+                            srtkImageReconstruction, "input_images")
         else:
-            self.wf.connect(srtkMaskImage01, "out_im_file", srtkImageReconstruction, "input_images")
+            self.wf.connect(srtkMaskImage01, "out_im_file",
+                            srtkImageReconstruction, "input_images")
 
         self.wf.connect(reduceFOV, "output_mask", srtkImageReconstruction, "input_masks")
         self.wf.connect(stacksOrdering, "stacks_order", srtkImageReconstruction, "stacks_order")
 
-        self.wf.connect(preprocessing_stage, ("outputnode.output_images", utils.sort_ascending),
+        self.wf.connect(preprocessing_stage, ("outputnode.output_images",
+                                              utils.sort_ascending),
                         srtkTVSuperResolution, "input_images")
 
-        self.wf.connect(srtkImageReconstruction, ("output_transforms", utils.sort_ascending), srtkTVSuperResolution, "input_transforms")
+        self.wf.connect(srtkImageReconstruction, ("output_transforms",
+                                                  utils.sort_ascending),
+                        srtkTVSuperResolution, "input_transforms")
         self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), srtkTVSuperResolution, "input_masks")
         self.wf.connect(stacksOrdering, "stacks_order", srtkTVSuperResolution, "stacks_order")
 
 
         if self.m_do_nlm_denoising:
-            self.wf.connect(srtkMaskImage01, "out_im_file", sdiComputation, "input_images")
-            self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), sdiComputation, "input_masks")
-            self.wf.connect(srtkImageReconstruction, "output_transforms", sdiComputation, "input_transforms")
-            self.wf.connect(srtkImageReconstruction, "output_sdi", sdiComputation, "input_reference")
+            self.wf.connect(srtkMaskImage01, "out_im_file",
+                            sdiComputation, "input_images")
+            self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending),
+                            sdiComputation, "input_masks")
+            self.wf.connect(srtkImageReconstruction, "output_transforms",
+                            sdiComputation, "input_transforms")
+            self.wf.connect(srtkImageReconstruction, "output_sdi",
+                            sdiComputation, "input_reference")
 
-            self.wf.connect(sdiComputation, "output_sdi", srtkTVSuperResolution, "input_sdi")
+            self.wf.connect(sdiComputation, "output_sdi",
+                            srtkTVSuperResolution, "input_sdi")
         else:
-            self.wf.connect(srtkImageReconstruction, "output_sdi", srtkTVSuperResolution, "input_sdi")
+            self.wf.connect(srtkImageReconstruction, "output_sdi",
+                            srtkTVSuperResolution, "input_sdi")
 
         if self.m_do_refine_hr_mask:
             # self.wf.connect(srtkIntensityStandardization02, ("output_images", utils.sort_ascending), srtkHRMask, "input_images")
-            self.wf.connect(preprocessing_stage, ("outputnode.output_images", utils.sort_ascending), srtkHRMask,
-                            "input_images")
+            self.wf.connect(preprocessing_stage, ("outputnode.output_images",
+                                                  utils.sort_ascending),
+                            srtkHRMask, "input_images")
 
             self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), srtkHRMask, "input_masks")
             self.wf.connect(srtkImageReconstruction, ("output_transforms", utils.sort_ascending), srtkHRMask, "input_transforms")

--- a/pymialsrtk/pipelines/anatomical/srr.py
+++ b/pymialsrtk/pipelines/anatomical/srr.py
@@ -475,7 +475,8 @@ class AnatomicalPipeline:
         self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending),
                         preprocessing_stage, "inputnode.input_masks")
 
-        self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), srtkMaskImage01, "in_mask")
+        self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending),
+                        srtkMaskImage01, "in_mask")
 
         self.wf.connect(preprocessing_stage, ("outputnode.output_images", utils.sort_ascending),
                         srtkMaskImage01, "in_file")
@@ -493,8 +494,10 @@ class AnatomicalPipeline:
             self.wf.connect(srtkMaskImage01, "out_im_file",
                             srtkImageReconstruction, "input_images")
 
-        self.wf.connect(reduceFOV, "output_mask", srtkImageReconstruction, "input_masks")
-        self.wf.connect(stacksOrdering, "stacks_order", srtkImageReconstruction, "stacks_order")
+        self.wf.connect(reduceFOV, "output_mask",
+                        srtkImageReconstruction, "input_masks")
+        self.wf.connect(stacksOrdering, "stacks_order",
+                        srtkImageReconstruction, "stacks_order")
 
         self.wf.connect(preprocessing_stage, ("outputnode.output_images",
                                               utils.sort_ascending),
@@ -503,7 +506,8 @@ class AnatomicalPipeline:
         self.wf.connect(srtkImageReconstruction, ("output_transforms",
                                                   utils.sort_ascending),
                         srtkTVSuperResolution, "input_transforms")
-        self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), srtkTVSuperResolution, "input_masks")
+        self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending),
+                        srtkTVSuperResolution, "input_masks")
         self.wf.connect(stacksOrdering, "stacks_order", srtkTVSuperResolution, "stacks_order")
 
 
@@ -529,8 +533,11 @@ class AnatomicalPipeline:
                                                   utils.sort_ascending),
                             srtkHRMask, "input_images")
 
-            self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), srtkHRMask, "input_masks")
-            self.wf.connect(srtkImageReconstruction, ("output_transforms", utils.sort_ascending), srtkHRMask, "input_transforms")
+            self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending),
+                            srtkHRMask, "input_masks")
+            self.wf.connect(srtkImageReconstruction, ("output_transforms",
+                                                      utils.sort_ascending),
+                            srtkHRMask, "input_transforms")
             self.wf.connect(srtkTVSuperResolution, "output_sr", srtkHRMask, "input_sr")
         else:
             self.wf.connect(srtkTVSuperResolution, "output_sr", srtkHRMask, "input_image")
@@ -538,8 +545,10 @@ class AnatomicalPipeline:
         self.wf.connect(srtkTVSuperResolution, "output_sr", srtkMaskImage02, "in_file")
         self.wf.connect(srtkHRMask, "output_srmask", srtkMaskImage02, "in_mask")
 
-        self.wf.connect(srtkTVSuperResolution, "output_sr", srtkN4BiasFieldCorrection, "input_image")
-        self.wf.connect(srtkMaskImage02, "out_im_file", srtkN4BiasFieldCorrection, "input_mask")
+        self.wf.connect(srtkTVSuperResolution, "output_sr",
+                        srtkN4BiasFieldCorrection, "input_image")
+        self.wf.connect(srtkMaskImage02, "out_im_file",
+                        srtkN4BiasFieldCorrection, "input_mask")
 
         # Datasinker
         finalFilenamesGeneration = Node(interface=postprocess.FilenamesGeneration(),

--- a/pymialsrtk/pipelines/anatomical/srr.py
+++ b/pymialsrtk/pipelines/anatomical/srr.py
@@ -401,6 +401,17 @@ class AnatomicalPipeline:
         srtkImageReconstruction.inputs.sub_ses = sub_ses
         srtkImageReconstruction.inputs.no_reg = self.m_skip_svr
 
+        if self.m_do_nlm_denoising:
+            srtkMaskImage01_nlm = MapNode(interface=preprocess.MialsrtkMaskImage(),
+                                      name='srtkMaskImage01_nlm',
+                                      iterfield=['in_file', 'in_mask'])
+            srtkMaskImage01_nlm.inputs.bids_dir = self.bids_dir
+
+            sdiComputation = Node(interface=reconstruction.MialsrtkSDIComputation(),
+                                      name='sdiComputation')
+            sdiComputation.inputs.sub_ses = sub_ses
+            sdiComputation.inputs.stacks_order = self.m_stacks
+
         srtkTVSuperResolution = Node(interface=reconstruction.MialsrtkTVSuperResolution(),
                                      name='srtkTVSuperResolution')
         srtkTVSuperResolution.inputs.bids_dir = self.bids_dir
@@ -464,25 +475,39 @@ class AnatomicalPipeline:
 
         self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), srtkMaskImage01, "in_mask")
 
+        self.wf.connect(preprocessing_stage, ("outputnode.output_images", utils.sort_ascending),
+                        srtkMaskImage01, "in_file")
+
         if self.m_do_nlm_denoising:
-            self.wf.connect(preprocessing_stage, ("outputnode.output_images_nlm", utils.sort_ascending), srtkMaskImage01, "in_file")
+            self.wf.connect(preprocessing_stage, ("outputnode.output_images_nlm", utils.sort_ascending),
+                            srtkMaskImage01_nlm, "in_file")
+            self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending),
+                            srtkMaskImage01_nlm, "in_mask")
+
+            self.wf.connect(srtkMaskImage01_nlm, "out_im_file", srtkImageReconstruction, "input_images")
         else:
-            self.wf.connect(preprocessing_stage, ("outputnode.output_images", utils.sort_ascending), srtkMaskImage01, "in_file")
+            self.wf.connect(srtkMaskImage01, "out_im_file", srtkImageReconstruction, "input_images")
 
-
-        self.wf.connect(srtkMaskImage01, "out_im_file", srtkImageReconstruction, "input_images")
         self.wf.connect(reduceFOV, "output_mask", srtkImageReconstruction, "input_masks")
         self.wf.connect(stacksOrdering, "stacks_order", srtkImageReconstruction, "stacks_order")
 
-        # self.wf.connect(srtkIntensityStandardization02, "output_images", srtkTVSuperResolution, "input_images")
-        self.wf.connect(preprocessing_stage, ("outputnode.output_images", utils.sort_ascending), srtkTVSuperResolution,
-                        "input_images")
+        self.wf.connect(preprocessing_stage, ("outputnode.output_images", utils.sort_ascending),
+                        srtkTVSuperResolution, "input_images")
 
         self.wf.connect(srtkImageReconstruction, ("output_transforms", utils.sort_ascending), srtkTVSuperResolution, "input_transforms")
         self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), srtkTVSuperResolution, "input_masks")
         self.wf.connect(stacksOrdering, "stacks_order", srtkTVSuperResolution, "stacks_order")
 
-        self.wf.connect(srtkImageReconstruction, "output_sdi", srtkTVSuperResolution, "input_sdi")
+
+        if self.m_do_nlm_denoising:
+            self.wf.connect(srtkMaskImage01, "out_im_file", sdiComputation, "input_images")
+            self.wf.connect(reduceFOV, ("output_mask", utils.sort_ascending), sdiComputation, "input_masks")
+            self.wf.connect(srtkImageReconstruction, "output_transforms", sdiComputation, "input_transforms")
+            self.wf.connect(srtkImageReconstruction, "output_sdi", sdiComputation, "input_reference")
+
+            self.wf.connect(sdiComputation, "output_sdi", srtkTVSuperResolution, "input_sdi")
+        else:
+            self.wf.connect(srtkImageReconstruction, "output_sdi", srtkTVSuperResolution, "input_sdi")
 
         if self.m_do_refine_hr_mask:
             # self.wf.connect(srtkIntensityStandardization02, ("output_images", utils.sort_ascending), srtkHRMask, "input_images")

--- a/src/MotionEstimation/CMakeLists.txt
+++ b/src/MotionEstimation/CMakeLists.txt
@@ -31,9 +31,23 @@ ADD_EXECUTABLE(mialsrtkImageReconstruction mialsrtkImageReconstruction.cxx
     ${CMAKE_SOURCE_DIR}/Code/Registration/mialsrtkRegistration.h
     ${CMAKE_SOURCE_DIR}/Code/Registration/mialsrtkRigidRegistration.h
 )
+
+ADD_EXECUTABLE(mialsrtkSDIComputation mialsrtkSDIComputation.cxx
+    ${CMAKE_SOURCE_DIR}/Code/Reconstruction/mialsrtkLowToHighImageResolutionMethod.h
+    ${CMAKE_SOURCE_DIR}/Code/Registration/mialsrtkSliceBySliceRigidRegistration.h
+    ${CMAKE_SOURCE_DIR}/Code/Reconstruction/mialsrtkResampleImageByInjectionFilter.h
+    ${CMAKE_SOURCE_DIR}/Code/Transformations/mialsrtkVersorSliceBySliceTransform.h
+    ${CMAKE_SOURCE_DIR}/Code/Transformations/mialsrtkSliceBySliceTransform.h
+    ${CMAKE_SOURCE_DIR}/Code/Reconstruction/mialsrtkImageIntersectionCalculator.h
+    ${CMAKE_SOURCE_DIR}/Code/Registration/mialsrtkRegistration.h
+    ${CMAKE_SOURCE_DIR}/Code/Registration/mialsrtkRigidRegistration.h
+)
+
 TARGET_LINK_LIBRARIES(mialsrtkImageReconstruction ${ITK_LIBRARIES})
+TARGET_LINK_LIBRARIES(mialsrtkSDIComputation ${ITK_LIBRARIES})
 #TARGET_LINK_LIBRARIES(mialsrtkImageReconstruction btkToolsLibrary ${ITK_LIBRARIES})
 
 INSTALL(TARGETS
                 mialsrtkImageReconstruction
+                mialsrtkSDIComputation
         DESTINATION bin)

--- a/src/MotionEstimation/mialsrtkSDIComputation.cxx
+++ b/src/MotionEstimation/mialsrtkSDIComputation.cxx
@@ -1,0 +1,318 @@
+
+/*=========================================================================
+
+Program: Performs Scattered Data Interpolation from a set of LR images, applying transforms
+Language: C++
+Date: $Date: 2012-28-12 14:00:00 +0100 (Fri, 28 Dec 2012) $
+Version: $Revision: 1 $
+Author: $Sebastien Tourbier$ - Adapted by $Priscille de Dumast$
+
+Copyright (c) 2017 Medical Image Analysis Laboratory (MIAL), Lausanne
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+==========================================================================*/
+
+
+#if defined(_MSC_VER)
+#pragma warning ( disable : 4786 )
+#endif
+
+/* Standard includes */
+#include <tclap/CmdLine.h>
+#include "stdio.h"
+
+/* Itk includes */
+#include "itkNormalizedCorrelationImageToImageMetric.h"
+#include "itkLinearInterpolateImageFunction.h"
+#include "itkMinimumMaximumImageCalculator.h"
+#include "itkEuler3DTransform.h"
+#include "itkTransformFileWriter.h"
+#include "itkImage.h"
+#include "itkImageMaskSpatialObject.h"
+#include "itkCastImageFilter.h"
+#include "itkImageDuplicator.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+
+
+#include "itkCurvatureAnisotropicDiffusionImageFilter.h"
+#include "itkSubtractImageFilter.h"
+#include "itkResampleImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
+
+#include "itkVersorRigid3DTransform.h"
+
+/*Btk includes*/
+//#include "btkSliceBySliceTransform.h"
+//#include "btkEulerSliceBySliceTransform.h"
+//#include "btkSliceBySliceTransformBase.h"
+//#include "btkLowToHighImageResolutionMethod.h"
+
+
+//#include "btkImageIntersectionCalculator.h"
+
+/* mialsrtk includes */
+//#include "mialsrtkLowToHighImageResolutionMethod.h"
+
+#include "mialsrtkVersorSliceBySliceTransform.h"
+#include "mialsrtkSliceBySliceTransformBase.h"
+#include "mialsrtkLowToHighImageResolutionMethod.h"
+
+#include "mialsrtkImageIntersectionCalculator.h"
+
+#include "mialsrtkResampleImageByInjectionFilter.h"
+#include "mialsrtkSliceBySliceRigidRegistration.h"
+#include "mialsrtkBSplineInterpolateImageFunction.h"
+
+
+
+int main( int argc, char *argv[] )
+{
+
+  try {
+
+  std::vector< std::string > input;
+  std::vector< std::string > mask;
+  std::vector< std::string > transform;
+  std::vector< std::string > roi;
+  std::vector< std::string > resampled;
+  unsigned int itMax;
+  double epsilon;
+  double margin;
+
+  const char *outImage = NULL;
+  const char *combinedMask = NULL;
+
+  std::string refImage;
+
+  // Parse arguments
+
+  TCLAP::CmdLine cmd("Creates a high resolution image from a set of low "
+      "resolution images", ' ', "Unversioned");
+
+  TCLAP::MultiArg<std::string> inputArg("i","input","Image file",true,"string",cmd);
+  TCLAP::MultiArg<std::string> maskArg("m","","Mask file",false,"string",cmd);
+  TCLAP::MultiArg<std::string> transformArg("t","transform","Transform output "
+      "file",false,"string",cmd);
+  //  TCLAP::MultiArg<std::string> roiArg("","roi","roi file (written as mask)",false,
+  //     "string",cmd);
+  TCLAP::ValueArg<std::string> outArg("o","output","High resolution image",true,
+      "","string",cmd);
+  TCLAP::ValueArg<std::string> refArg("r","reference","Reference Image",false, "","string",cmd);
+
+
+  /*TCLAP::SwitchArg  boxSwitchArg("","box","Use intersections for roi calculation",false);
+  TCLAP::SwitchArg  maskSwitchArg("","mask","Use masks for roi calculation",false);
+  TCLAP::SwitchArg  allSwitchArg("","all","Use the whole image FOV",false);
+
+  std::vector<TCLAP::Arg*>  xorlist;
+  xorlist.push_back(&boxSwitchArg);
+  xorlist.push_back(&maskSwitchArg);
+  xorlist.push_back(&allSwitchArg);
+
+  cmd.xorAdd( xorlist );
+  */
+
+  // Parse the argv array.
+  cmd.parse( argc, argv );
+
+  input = inputArg.getValue();
+  mask = maskArg.getValue();
+  transform = transformArg.getValue();
+
+  refImage = refArg.getValue();
+  outImage = outArg.getValue().c_str();
+
+  //roi = roiArg.getValue();
+
+    // typedefs
+
+  const    unsigned int    Dimension = 3;
+  typedef  float           PixelType;
+
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef ImageType::Pointer                  ImagePointer;
+
+  typedef ImageType::RegionType               RegionType;
+  typedef std::vector< RegionType >           RegionArrayType;
+
+  typedef itk::ImageFileReader< ImageType  >  ImageReaderType;
+
+
+
+  typedef mialsrtk::SliceBySliceTransformBase< double, Dimension > TransformBaseType;
+  typedef mialsrtk::SliceBySliceTransform< double, Dimension > TransformType;
+  typedef TransformType::Pointer                          TransformPointer;
+
+  // Register the SliceBySlice transform (a non-default ITK transform) with the TransformFactory of ITK
+  itk::TransformFactory<TransformType>::RegisterTransform();
+
+  typedef itk::TransformFileReader     TransformReaderType;
+  typedef TransformReaderType::TransformListType * TransformListType;
+
+
+  typedef itk::Image< unsigned char, Dimension >    ImageMaskType;
+  typedef ImageMaskType::Pointer                    ImageMaskPointer;
+
+  typedef itk::ImageFileReader< ImageMaskType >     MaskReaderType;
+  typedef itk::ImageMaskSpatialObject< Dimension >  MaskType;
+  typedef MaskType::Pointer  MaskPointer;
+
+
+
+  /* Registration type required in case of slice by slice transformations
+  A rigid transformation is employed because there is not distortions like
+  in diffusion imaging. We have performed a comparison of accuracy between
+  both types of transformations. */
+  typedef mialsrtk::SliceBySliceRigidRegistration<ImageType> RegistrationType;
+  typedef RegistrationType::Pointer RegistrationPointer;
+
+  // Registration type required in case of 3D affine trasforms
+  typedef mialsrtk::RigidRegistration<ImageType> Rigid3DRegistrationType;
+  typedef Rigid3DRegistrationType::Pointer Rigid3DRegistrationPointer;
+
+  // Slice by slice transform definition (typically for in utero reconstructions)
+  typedef mialsrtk::SliceBySliceTransformBase< double, Dimension > TransformBaseType;
+  typedef mialsrtk::SliceBySliceTransform< double, Dimension > TransformType;
+  typedef TransformType::Pointer                          TransformPointer;
+
+
+
+  // Rigid 3D transform definition (typically for reconstructions in adults)
+  //typedef itk::Euler3DTransform< double > Rigid3DTransformType;
+  typedef itk::VersorRigid3DTransform< double > Rigid3DTransformType;
+  typedef Rigid3DTransformType::Pointer   Rigid3DTransformPointer;
+
+  // This filter does a rigid registration over all the LR images and compute the average image in HR space
+  //typedef mialsrtk::LowToHighImageResolutionMethod<ImageType,Rigid3DTransformType > LowToHighResFilterType;
+  typedef mialsrtk::LowToHighImageResolutionMethod<ImageType,Rigid3DTransformType > LowToHighResFilterType;
+  LowToHighResFilterType::Pointer lowToHighResFilter = LowToHighResFilterType::New();
+
+  // Resampler type required in case of a slice by slice transform
+  typedef mialsrtk::ResampleImageByInjectionFilter< ImageType, ImageType
+                                               >  ResamplerType;
+
+  typedef itk::NormalizedCorrelationImageToImageMetric< ImageType,
+                                                        ImageType > NCMetricType;
+
+  typedef mialsrtk::ImageIntersectionCalculator<ImageType> IntersectionCalculatorType;
+  IntersectionCalculatorType::Pointer intersectionCalculator = IntersectionCalculatorType::New();
+
+  typedef itk::CastImageFilter<ImageType,ImageMaskType> CasterType;
+  typedef itk::ImageDuplicator<ImageType> DuplicatorType;
+
+  // Filter setup
+  unsigned int numberOfImages = input.size();
+  std::vector< ImagePointer >         images(numberOfImages);
+  std::vector< ImageMaskPointer >     imageMasks(numberOfImages);
+
+  std::vector< TransformPointer >     transforms(numberOfImages);
+  std::vector< Rigid3DTransformPointer >     rigid3DTransforms(numberOfImages);
+
+  std::vector< RegistrationPointer >  registration(numberOfImages);
+  std::vector< Rigid3DRegistrationPointer >  rigid3DRegistration(numberOfImages);
+
+  std::vector< MaskPointer >          masks(numberOfImages);
+  std::vector< RegionType >           rois(numberOfImages);
+
+  ImagePointer hrImage;
+  ImagePointer hrRefImage;
+
+  std::cout<<"Reading the reference image : "<<refImage<<"\n";
+  ImageReaderType::Pointer imageReader = ImageReaderType::New();
+  imageReader -> SetFileName( refImage );
+  imageReader -> Update();
+  hrRefImage = imageReader -> GetOutput();
+
+
+  for (unsigned int i=0; i<numberOfImages; i++)
+  {
+    std::cout<<"Reading image : "<<input[i].c_str()<<"\n";
+    ImageReaderType::Pointer imageReader = ImageReaderType::New();
+    imageReader -> SetFileName( input[i].c_str() );
+    imageReader -> Update();
+    images[i] = imageReader -> GetOutput();
+
+
+
+    std::cout<<"Reading masks:"<<mask[i]<<std::endl;
+    MaskReaderType::Pointer maskReader = MaskReaderType::New();
+    maskReader -> SetFileName( mask[i].c_str() );
+    maskReader -> Update();
+    imageMasks[i] = maskReader -> GetOutput();
+
+    masks[i] = MaskType::New();
+    masks[i] -> SetImage( imageMasks[i] );
+    rois[i] = masks[i] -> GetAxisAlignedBoundingBoxRegion();
+
+
+    std::cout<<"Reading transform:"<<transform[i]<<std::endl<<std::endl;
+    TransformReaderType::Pointer transformReader = TransformReaderType::New();
+    transformReader -> SetFileName( transform[i] );
+    transformReader -> Update();
+
+    TransformListType transformsList = transformReader->GetTransformList();
+    TransformReaderType::TransformListType::const_iterator titr = transformsList->begin();
+    TransformPointer trans = static_cast< TransformType * >( titr->GetPointer() );
+
+    //transforms[i]= TransformType::New();
+    transforms[i] = TransformType::New();
+    transforms[i]=static_cast< TransformType * >( titr->GetPointer() );
+    //transforms[i] -> SetImage( preImages[i] );
+    //transforms[i] -> SetImage( orientImageFilter[i] -> GetOutput());
+    transforms[i] -> SetImage( imageReader -> GetOutput());
+
+  }
+
+
+
+
+
+  std::cout << std::endl; std::cout.flush();
+
+  // Inject images
+
+  std::cout << "Injecting images ... "; std::cout.flush();
+
+
+  ResamplerType::Pointer resampler = ResamplerType::New();
+
+  for (unsigned int i=0; i<numberOfImages; i++)
+  {
+    resampler -> AddInput( images[i] );
+    resampler -> AddMask( imageMasks[i] );
+    resampler -> AddRegion( rois[i] );
+
+    resampler -> SetTransform(i, transforms[i]) ;
+  }
+
+  resampler -> UseReferenceImageOn();
+  resampler -> SetReferenceImage( hrRefImage );
+  // resampler -> SetReferenceImageMask(lowToHighResFilter -> GetImageMaskCombination());
+
+  // resampler -> SetUseDebluringKernel( debluringArg.isSet() );
+
+  resampler -> Update();
+
+
+  hrImage = resampler -> GetOutput();
+
+  std::cout << "done. " << std::endl; std::cout.flush();
+
+
+  // Write HR image
+
+  typedef itk::ImageFileWriter< ImageType >  WriterType;
+
+  WriterType::Pointer writer =  WriterType::New();
+  writer-> SetFileName( outImage );
+  writer-> SetInput( hrImage );
+  writer-> Update();
+
+
+  return EXIT_SUCCESS;
+
+  } catch (TCLAP::ArgException &e)  // catch any exceptions
+  { std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl; }
+}

--- a/src/MotionEstimation/mialsrtkSDIComputation.cxx
+++ b/src/MotionEstimation/mialsrtkSDIComputation.cxx
@@ -2,10 +2,12 @@
 /*=========================================================================
 
 Program: Performs Scattered Data Interpolation from a set of LR images, applying transforms
+that are computed in mialsrtkImageReconstruction.
+This program is a stripped down version of mialsrtkImageReconstruction
 Language: C++
-Date: $Date: 2012-28-12 14:00:00 +0100 (Fri, 28 Dec 2012) $
+Date: $Date: 2022-07-12 14:00:00 +0100 (12 Jul 2022) $
 Version: $Revision: 1 $
-Author: $Sebastien Tourbier$ - Adapted by $Priscille de Dumast$
+Author: $ $Priscille de Dumast$
 
 Copyright (c) 2017 Medical Image Analysis Laboratory (MIAL), Lausanne
   This software is distributed WITHOUT ANY WARRANTY; without even


### PR DESCRIPTION
When `do_nlm_denoised=true`, motion estimation is computed on these images and it generates an SDI. To avoid using an SDI computed with denoised images as reference on the TV, we create a new interface which computes an SDI from non-denoised images using the transforms computed on the denoised ones.