### PR TITLE
197 bypass preprocessing

### DIFF
--- a/docker/bidsapp/run.py
+++ b/docker/bidsapp/run.py
@@ -201,6 +201,7 @@ def check_participants_params(participants_params):
     allowed_keys = [
         "skip_svr",
         "do_refine_hr_mask",
+        "skip_preprocessing",
         "do_nlm_denoising",
         "skip_stacks_ordering",
         "do_reconstruct_labels",

--- a/documentation/usage.rst
+++ b/documentation/usage.rst
@@ -79,8 +79,7 @@ where:
 
         * ``"do_refine_hr_mask"`` (optional) indicates whether a refinement of the HR mask should be performed. (default is False)
         
-        * ``"skip_preprocessing"`` (optional) indicates whether the preprocessing stage should be skipped. (default is False)
-        .. note:: In this case, a minimal preprocessing is still kept, including reducing the field-of-view based on the brain masks as well as masking of the images to keep only the ROI. 
+        * ``"skip_preprocessing"`` (optional) indicates whether the preprocessing stage should be skipped. A minimal preprocessing is still computed: the field-of-view is reduced based on the brain masks and the LR series are masked on the ROI. (default is False)
         .. note:: This option requires input images to be normalised in the range [0,255] prior to running the code with this option. The projection step of the TV algorithm will otherwise clip values to 255. 
         * ``"do_nlm_denoising"`` (optional) indicates whether the NLM denoising preprocessing should be performed prior to motion estimation. (default is False)
 

--- a/documentation/usage.rst
+++ b/documentation/usage.rst
@@ -87,9 +87,8 @@ where:
 
         * ``"skip_stacks_ordering"`` (optional) indicates whether the order of stacks specified in ``"stacks"`` should be kept or re-computed. (default is False)
 
-        * ``"do_anat_orientation"`` (optional) indicates whether the alignement into anatomical planes should be performed. (default is False)
-        If True, path to a directory containing STA atlas (Gholipour et al., 2017 [1]_, [2]_) must be mounted to `/sta`.
-
+        * ``"do_anat_orientation"`` (optional) indicates whether the alignement into anatomical planes should be performed. If True, path to a directory containing STA atlas (Gholipour et al., 2017 [1]_, [2]_) must be mounted to `/sta`. (default is False)
+        
         * ``"preproc_do_registration"`` (optional) indicates whether the Slice-to-Volume Registration should be computed in the ``"preprocessing"`` run (default is False).
 
         * ``"do_multi_parameters"`` (optional) enables running the super-resolution reconstruction with lists of parameters. The algorithm will

--- a/documentation/usage.rst
+++ b/documentation/usage.rst
@@ -73,19 +73,22 @@ where:
     
     * ``"run_type"`` (optional): defines the type of run that should be done. It can be set between `sr` (super-resolution) and `preprocessing` (preprocessing-only). (default is ``"sr"``)
     
-    * ``"custom_interfaces"`` (optional): indicates weither optional interfaces of the pipeline should be performed.
+    * ``"custom_interfaces"`` (optional): indicates whether optional interfaces of the pipeline should be performed.
 
         * ``"skip_svr"`` (optional) the Slice-to-Volume Registration should be skipped in the image reconstruction. (default is False)
 
-        * ``"do_refine_hr_mask"`` (optional) indicates weither a refinement of the HR mask should be performed. (default is False)
+        * ``"do_refine_hr_mask"`` (optional) indicates whether a refinement of the HR mask should be performed. (default is False)
+        
+        * ``"skip_preprocessing"`` (optional) indicates whether the preprocessing stage should be skipped. (default is False)
+        .. note:: In this case, a minimal preprocessing is still kept, including reducing the field-of-view based on the brain masks as well as masking of the images to keep only the ROI. 
+        .. note:: This option requires input images to be normalised in the range [0,255] prior to running the code with this option. The projection step of the TV algorithm will otherwise clip values to 255. 
+        * ``"do_nlm_denoising"`` (optional) indicates whether the NLM denoising preprocessing should be performed prior to motion estimation. (default is False)
 
-        * ``"do_nlm_denoising"`` (optional) indicates weither the NLM denoising preprocessing should be performed prior to motion estimation. (default is False)
+        * ``"do_reconstruct_labels"`` (optional) indicates whether the reconstruction of LR label maps should be performed together with T2w images. (default is False)
 
-        * ``"do_reconstruct_labels"`` (optional) indicates weither the reconstruction of LR label maps should be performed together with T2w images. (default is False)
+        * ``"skip_stacks_ordering"`` (optional) indicates whether the order of stacks specified in ``"stacks"`` should be kept or re-computed. (default is False)
 
-        * ``"skip_stacks_ordering"`` (optional) indicates weither the order of stacks specified in ``"stacks"`` should be kept or re-computed. (default is False)
-
-        * ``"do_anat_orientation"`` (optional) indicates weither the alignement into anatomical planes should be performed. (default is False)
+        * ``"do_anat_orientation"`` (optional) indicates whether the alignement into anatomical planes should be performed. (default is False)
         If True, path to a directory containing STA atlas (Gholipour et al., 2017 [1]_, [2]_) must be mounted to `/sta`.
 
         * ``"preproc_do_registration"`` (optional) indicates whether the Slice-to-Volume Registration should be computed in the ``"preprocessing"`` run (default is False).

--- a/pymialsrtk/pipelines/anatomical/preprocessing.py
+++ b/pymialsrtk/pipelines/anatomical/preprocessing.py
@@ -135,6 +135,13 @@ class PreprocessingPipeline(AbstractAnatomicalPipeline):
         )
 
         if p_dict_custom_interfaces is not None:
+
+            self.m_skip_preprocessing = (
+                p_dict_custom_interfaces["skip_preprocessing"]
+                if "skip_preprocessing" in p_dict_custom_interfaces.keys()
+                else False
+            )
+
             self.m_do_nlm_denoising = (
                 p_dict_custom_interfaces["do_nlm_denoising"]
                 if "do_nlm_denoising" in p_dict_custom_interfaces.keys()
@@ -167,6 +174,7 @@ class PreprocessingPipeline(AbstractAnatomicalPipeline):
             self.check_parameters_integrity(p_dict_custom_interfaces)
 
         else:
+            self.m_skip_preprocessing = False
             self.m_do_nlm_denoising = False
             self.m_skip_stacks_ordering = False
             self.m_do_registration = False
@@ -250,6 +258,7 @@ class PreprocessingPipeline(AbstractAnatomicalPipeline):
         )
 
         preprocessing_stage = preproc_stage.create_preproc_stage(
+            p_skip_preprocessing=self.m_skip_preprocessing,
             p_do_nlm_denoising=self.m_do_nlm_denoising,
             p_do_reconstruct_labels=False,
             p_verbose=self.m_verbose,

--- a/pymialsrtk/pipelines/anatomical/preprocessing.py
+++ b/pymialsrtk/pipelines/anatomical/preprocessing.py
@@ -180,6 +180,12 @@ class PreprocessingPipeline(AbstractAnatomicalPipeline):
             self.m_do_registration = False
             self.m_skip_svr = False
 
+        if self.m_skip_preprocessing:
+            if self.m_do_nlm_denoising:
+                raise RuntimeError(
+                    "`do_nlm denoising` is incompatible with `skip_preprocessing`."
+                )
+
     def check_parameters_integrity(self, p_dict_custom_interfaces):
         """Check whether the custom interfaces dictionary
         contains only keys that are used in preprocessing,

--- a/pymialsrtk/pipelines/anatomical/srr.py
+++ b/pymialsrtk/pipelines/anatomical/srr.py
@@ -196,6 +196,12 @@ class SRReconPipeline(AbstractAnatomicalPipeline):
 
         # Custom interfaces and default values.
         if p_dict_custom_interfaces is not None:
+            self.m_skip_preprocessing = (
+                p_dict_custom_interfaces["skip_preprocessing"]
+                if "skip_preprocessing" in p_dict_custom_interfaces.keys()
+                else False
+            )
+
             self.m_do_nlm_denoising = (
                 p_dict_custom_interfaces["do_nlm_denoising"]
                 if "do_nlm_denoising" in p_dict_custom_interfaces.keys()
@@ -331,7 +337,6 @@ class SRReconPipeline(AbstractAnatomicalPipeline):
         where the output of node i goes to the input of node i+1.
 
         """
-
         self.m_wf = pe.Workflow(
             name=self.m_pipeline_name, base_dir=self.m_wf_base_dir
         )
@@ -372,6 +377,7 @@ class SRReconPipeline(AbstractAnatomicalPipeline):
         )
 
         preprocessing_stage = preproc_stage.create_preproc_stage(
+            p_skip_preprocessing=self.m_skip_preprocessing,
             p_do_nlm_denoising=self.m_do_nlm_denoising,
             p_do_reconstruct_labels=self.m_do_reconstruct_labels,
             p_verbose=self.m_verbose,

--- a/pymialsrtk/pipelines/anatomical/srr.py
+++ b/pymialsrtk/pipelines/anatomical/srr.py
@@ -257,7 +257,7 @@ class SRReconPipeline(AbstractAnatomicalPipeline):
             )
 
         else:
-
+            self.m_skip_preprocessing = False
             self.m_do_nlm_denoising = False
             self.m_skip_stacks_ordering = False
             self.m_skip_svr = False
@@ -266,6 +266,12 @@ class SRReconPipeline(AbstractAnatomicalPipeline):
             self.m_do_anat_orientation = False
             self.m_do_multi_parameters = False
             self.m_do_srr_assessment = False
+
+        if self.m_skip_preprocessing:
+            if self.m_do_nlm_denoising:
+                raise RuntimeError(
+                    "`do_nlm denoising` is incompatible with `skip_preprocessing`."
+                )
 
         if self.m_do_anat_orientation:
             if not os.path.isdir("/sta"):

--- a/pymialsrtk/workflows/preproc_stage.py
+++ b/pymialsrtk/workflows/preproc_stage.py
@@ -77,10 +77,6 @@ def create_preproc_stage(
     if p_do_reconstruct_labels:
         input_fields += ["input_labels"]
         output_fields += ["output_labels"]
-    if p_skip_preprocessing:
-        assert (
-            not p_do_nlm_denoising
-        ), "ERROR: `do_nlm denoising` is incompatible with `skip_preprocessing`."
 
     inputnode = pe.Node(
         interface=util.IdentityInterface(fields=input_fields), name="inputnode"


### PR DESCRIPTION
Provide the option with `skip_preprocessing` to almost entirely bypass preprocessing, applying only `reduce_FOV` and `maskImage`